### PR TITLE
Add additional attributes to package.json

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const Bot = require('./src/handler/CrownBot')
 const { prefix, token, ownerID, apikey } = require('./config.json')
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,6 @@
 {
+  "name": "crown-bot",
+  "version": "1.0.0",
   "dependencies": {
     "discord.js": "^11.5.1",
     "node-fetch": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "crown-bot",
   "version": "1.0.0",
+  "bin": "index.js",
   "dependencies": {
     "discord.js": "^11.5.1",
     "node-fetch": "^2.6.0",


### PR DESCRIPTION
Adds required fields to `package.json` as missing them out can cause issues with some systems such as Nix.