### PR TITLE
Updated init() to handle unhandled promise rejection exception

### DIFF
--- a/src/handler/CrownBot.js
+++ b/src/handler/CrownBot.js
@@ -71,7 +71,12 @@ class CrownBot extends Client {
             .loadModels()
             .configureLogging()
             .login(this.token)
-            .then(() => console.log('Logged in.'))
+            .catch(e => console.log(`An error occurred when attempting to log in. ${e}`))
+            .then(f => {
+                if (f) {
+                    console.log('Logged in.')
+                }
+            })
     }
 }
 


### PR DESCRIPTION
I've made a small edit to CrownBot.js to handle promise rejections for the init() method. This will remove the unhandled promise rejection deprecation warning from the console, and replace it with an error message instead